### PR TITLE
`swift package update`.

### DIFF
--- a/Package.pins
+++ b/Package.pins
@@ -5,7 +5,7 @@
       "package": "Baby",
       "reason": null,
       "repositoryURL": "https://github.com/nixzhu/Baby.git",
-      "version": "0.19.0"
+      "version": "0.20.0"
     },
     {
       "package": "CLibreSSL",


### PR DESCRIPTION
The PR fix the issue that version in `Package.pins` do not match version in `Package.resolved` which will make `swift build` fail.
